### PR TITLE
Add notebook with QPControl standing controller demo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ git:
   depth: 99999999
 before_script:
  - julia -e 'Pkg.clone("https://github.com/tkoolen/SimpleQP.jl"); Pkg.clone("https://github.com/tkoolen/QPControl.jl.git")'
- - julia -e 'Pkg.add("JSExpr"); Pkg.checkout("JSExpr")'
 script:
 - $TESTCMD -e 'Pkg.clone(pwd()); Pkg.build("HumanoidLCMSim"); Pkg.test("HumanoidLCMSim"; coverage=true)'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ notifications:
 git:
   depth: 99999999
 before_script:
+ - julia -e 'Pkg.clone("https://github.com/tkoolen/SimpleQP.jl"); Pkg.clone("https://github.com/tkoolen/QPControl.jl.git")'
  - julia -e 'Pkg.add("JSExpr"); Pkg.checkout("JSExpr")'
 script:
 - $TESTCMD -e 'Pkg.clone(pwd()); Pkg.build("HumanoidLCMSim"); Pkg.test("HumanoidLCMSim"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ Compat
 AtlasRobot
 ValkyrieRobot
 BotCoreLCMTypes
+Reexport

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
 RigidBodyDynamics 0.7.0
 RigidBodySim 0.3.0
-LCMCore 0.2.0
+LCMCore 0.3.0
 Compat
 AtlasRobot
 ValkyrieRobot

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -51,7 +51,8 @@
    "outputs": [],
    "source": [
     "# create low level controller\n",
-    "const lowlevel = MomentumBasedController{4}(mechanism, optimizer);\n",
+    "info = AtlasSim.atlasrobotinfo(mechanism)\n",
+    "const lowlevel = MomentumBasedController{4}(mechanism, optimizer, floatingjoint=info.floatingjoint);\n",
     "for body in bodies(mechanism)\n",
     "    for point in RigidBodyDynamics.contact_points(body)\n",
     "        position = RigidBodyDynamics.Contact.location(point)\n",
@@ -71,7 +72,6 @@
    "outputs": [],
    "source": [
     "# create standing controller\n",
-    "info = AtlasSim.atlasrobotinfo(mechanism)\n",
     "nominalstate = MechanismState(mechanism)\n",
     "AtlasSim.initialize!(nominalstate, info)\n",
     "pelvis = successor(info.floatingjoint, mechanism)\n",

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "    <script class='js-collapse-script'>\n",
+       "        var curMatch =\n",
+       "            window.location.href\n",
+       "            .match(/(.*?)\\/notebooks\\/.*\\.ipynb/);\n",
+       "\n",
+       "        curMatch = curMatch ||\n",
+       "            window.location.href\n",
+       "            .match(/(.*?)\\/apps\\/.*\\.ipynb/);\n",
+       "\n",
+       "        if ( curMatch ) {\n",
+       "            $('head').append('<base href=\"' + curMatch[1] + '/\">');\n",
+       "        }\n",
+       "    </script>\n"
+      ],
+      "text/plain": [
+       "HTML{String}(\"    <script class='js-collapse-script'>\\n        var curMatch =\\n            window.location.href\\n            .match(/(.*?)\\\\/notebooks\\\\/.*\\\\.ipynb/);\\n\\n        curMatch = curMatch ||\\n            window.location.href\\n            .match(/(.*?)\\\\/apps\\\\/.*\\\\.ipynb/);\\n\\n        if ( curMatch ) {\\n            \\$('head').append('<base href=\\\"' + curMatch[1] + '/\\\">');\\n        }\\n    </script>\\n\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/webio/dist/bundle.js'></script>"
+      ],
+      "text/plain": [
+       "HTML{String}(\"<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/webio/dist/bundle.js'></script>\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/providers/ijulia_setup.js'></script>"
+      ],
+      "text/plain": [
+       "HTML{String}(\"<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/providers/ijulia_setup.js'></script>\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "  <script class='js-collapse-script'>\n",
+       "    $('.js-collapse-script').parent('.output_subarea').css('padding', '0');\n",
+       "  </script>\n"
+      ],
+      "text/plain": [
+       "HTML{String}(\"  <script class='js-collapse-script'>\\n    \\$('.js-collapse-script').parent('.output_subarea').css('padding', '0');\\n  </script>\\n\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mLoading HttpServer methods...\n",
+      "\u001b[39m"
+     ]
+    }
+   ],
+   "source": [
+    "using Compat\n",
+    "using QPControl\n",
+    "using RigidBodyDynamics\n",
+    "using AtlasRobot\n",
+    "using HumanoidLCMSim\n",
+    "using HumanoidLCMSim.AtlasSim\n",
+    "using Compat.Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: using Juno.input in module InteractBase conflicts with an existing identifier.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load URDF\n",
+    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism())\n",
+    "remove_fixed_tree_joints!(mechanism);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create optimizer\n",
+    "using MathOptInterface\n",
+    "using OSQP.MathOptInterfaceOSQP\n",
+    "const MOI = MathOptInterface\n",
+    "optimizer = OSQPOptimizer()\n",
+    "MOI.set!(optimizer, OSQPSettings.Verbose(), false)\n",
+    "MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-5)\n",
+    "MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-5)\n",
+    "MOI.set!(optimizer, OSQPSettings.MaxIter(), 5000)\n",
+    "MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create low level controller\n",
+    "lowlevel = MomentumBasedController{4}(mechanism, optimizer);\n",
+    "for body in bodies(mechanism)\n",
+    "    for point in RigidBodyDynamics.contact_points(body)\n",
+    "        position = RigidBodyDynamics.Contact.location(point)\n",
+    "        normal = FreeVector3D(default_frame(body), 0.0, 0.0, 1.0)\n",
+    "        μ = point.model.friction.μ\n",
+    "        contact = addcontact!(lowlevel, body, position, normal, μ)\n",
+    "        contact.maxnormalforce[] = 1e6 # TODO\n",
+    "        contact.weight[] = 1e-3\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create standing controller\n",
+    "info = AtlasSim.atlasrobotinfo(mechanism)\n",
+    "nominalstate = MechanismState(mechanism)\n",
+    "AtlasSim.initialize!(nominalstate, info)\n",
+    "pelvis = successor(info.floatingjoint, mechanism)\n",
+    "comref = center_of_mass(nominalstate) - FreeVector3D(root_frame(mechanism), 0., 0., 0.05)\n",
+    "standingcontroller = StandingController(lowlevel, collect(values(info.feet)), pelvis, nominalstate, comref=comref);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create LCM control publisher\n",
+    "publisher = LCMControlPublisher(info, standingcontroller;\n",
+    "    robot_state_channel=\"EST_ROBOT_STATE\",\n",
+    "    robot_command_channel=\"ATLAS_COMMAND\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Publishing START_MIT_STAND\n"
+     ]
+    }
+   ],
+   "source": [
+    "# run simulation\n",
+    "sol = AtlasSim.run(final_time = 10.0);\n",
+    "flush(stdout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1m\u001b[32mTest Passed\u001b[39m\u001b[22m"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Simulated 10.0 s in 14.885309275 s (0.6718033072241961 x realtime).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# checks\n",
+    "finalstate = MechanismState(mechanism)\n",
+    "copyto!(finalstate, sol.u[end])\n",
+    "@test sol.retcode == :Success\n",
+    "@test center_of_mass(finalstate) ≈ comref atol=2e-2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.4",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -2,80 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "    <script class='js-collapse-script'>\n",
-       "        var curMatch =\n",
-       "            window.location.href\n",
-       "            .match(/(.*?)\\/notebooks\\/.*\\.ipynb/);\n",
-       "\n",
-       "        curMatch = curMatch ||\n",
-       "            window.location.href\n",
-       "            .match(/(.*?)\\/apps\\/.*\\.ipynb/);\n",
-       "\n",
-       "        if ( curMatch ) {\n",
-       "            $('head').append('<base href=\"' + curMatch[1] + '/\">');\n",
-       "        }\n",
-       "    </script>\n"
-      ],
-      "text/plain": [
-       "HTML{String}(\"    <script class='js-collapse-script'>\\n        var curMatch =\\n            window.location.href\\n            .match(/(.*?)\\\\/notebooks\\\\/.*\\\\.ipynb/);\\n\\n        curMatch = curMatch ||\\n            window.location.href\\n            .match(/(.*?)\\\\/apps\\\\/.*\\\\.ipynb/);\\n\\n        if ( curMatch ) {\\n            \\$('head').append('<base href=\\\"' + curMatch[1] + '/\\\">');\\n        }\\n    </script>\\n\")"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/webio/dist/bundle.js'></script>"
-      ],
-      "text/plain": [
-       "HTML{String}(\"<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/webio/dist/bundle.js'></script>\")"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/providers/ijulia_setup.js'></script>"
-      ],
-      "text/plain": [
-       "HTML{String}(\"<script class='js-collapse-script' src='/assetserver/9ed50fe60e4c3cfba5d8d51afc0a1ba695b21d72-assets/providers/ijulia_setup.js'></script>\")"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "  <script class='js-collapse-script'>\n",
-       "    $('.js-collapse-script').parent('.output_subarea').css('padding', '0');\n",
-       "  </script>\n"
-      ],
-      "text/plain": [
-       "HTML{String}(\"  <script class='js-collapse-script'>\\n    \\$('.js-collapse-script').parent('.output_subarea').css('padding', '0');\\n  </script>\\n\")"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mLoading HttpServer methods...\n",
-      "\u001b[39mWARNING: using Juno.input in module InteractBase conflicts with an existing identifier.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Compat\n",
     "using QPControl\n",
@@ -83,24 +12,45 @@
     "using AtlasRobot\n",
     "using HumanoidLCMSim\n",
     "using HumanoidLCMSim.AtlasSim\n",
-    "\n",
+    "using JSExpr # FIXME: https://github.com/JunoLab/Blink.jl/issues/134"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# load URDF\n",
-    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism());\n",
-    "\n",
+    "const mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism());"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create optimizer\n",
     "using MathOptInterface\n",
     "using OSQP.MathOptInterfaceOSQP\n",
     "const MOI = MathOptInterface\n",
-    "optimizer = OSQPOptimizer()\n",
+    "const optimizer = OSQPOptimizer()\n",
     "MOI.set!(optimizer, OSQPSettings.Verbose(), false)\n",
     "MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-5)\n",
     "MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-5)\n",
     "MOI.set!(optimizer, OSQPSettings.MaxIter(), 5000)\n",
-    "MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior\n",
-    "sleep(0.5)\n",
-    "\n",
+    "MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create low level controller\n",
-    "lowlevel = MomentumBasedController{4}(mechanism, optimizer);\n",
+    "const lowlevel = MomentumBasedController{4}(mechanism, optimizer);\n",
     "for body in bodies(mechanism)\n",
     "    for point in RigidBodyDynamics.contact_points(body)\n",
     "        position = RigidBodyDynamics.Contact.location(point)\n",
@@ -110,86 +60,63 @@
     "        contact.maxnormalforce[] = 1e6 # TODO\n",
     "        contact.weight[] = 1e-3\n",
     "    end\n",
-    "end\n",
-    "\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create standing controller\n",
     "info = AtlasSim.atlasrobotinfo(mechanism)\n",
     "nominalstate = MechanismState(mechanism)\n",
     "AtlasSim.initialize!(nominalstate, info)\n",
     "pelvis = successor(info.floatingjoint, mechanism)\n",
     "comref = center_of_mass(nominalstate) - FreeVector3D(root_frame(mechanism), 0., 0., 0.05)\n",
-    "standingcontroller = StandingController(lowlevel, collect(values(info.feet)), pelvis, nominalstate, comref=comref);\n",
-    "\n",
+    "const standingcontroller = StandingController(\n",
+    "    lowlevel, collect(values(info.feet)), pelvis, nominalstate, comref=comref);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# create LCM control publisher\n",
-    "publisher = LCMControlPublisher(info, standingcontroller;\n",
+    "const publisher = LCMControlPublisher(info, standingcontroller;\n",
     "    robot_state_channel=\"EST_ROBOT_STATE\",\n",
     "    robot_command_channel=\"ATLAS_COMMAND\");"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Task (queued) @0x00007fe38d330fd0"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "handle(publisher, async=true)"
+    "# start listening for state messages and publishing command messages in response\n",
+    "handle(publisher, async=true);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Publishing START_MIT_STAND\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run simulation\n",
     "using HumanoidLCMSim\n",
-    "controlΔt = 1 / 500\n",
-    "sol = AtlasSim.run(controlΔt = controlΔt, final_time = 10.0);\n",
-    "flush(stdout)"
+    "sol = AtlasSim.run(controlΔt = 1 / 500, final_time = 5.0);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[1m\u001b[32mTest Passed\u001b[39m\u001b[22m"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Simulated 10.0 s in 17.413842434 s (0.5742557989657299 x realtime).\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# checks\n",
     "using Compat.Test\n",
@@ -197,7 +124,7 @@
     "copyto!(finalstate, sol.u[end])\n",
     "@test sol.retcode == :Success\n",
     "@test center_of_mass(finalstate) ≈ comref atol=2e-2\n",
-    "@test norm(velocity(finalstate)) ≈ 0 atol=1e-4"
+    "@test norm(velocity(finalstate)) ≈ 0 atol=5e-3"
    ]
   },
   {

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -101,8 +101,7 @@
    ],
    "source": [
     "# load URDF\n",
-    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism())\n",
-    "remove_fixed_tree_joints!(mechanism);"
+    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism());"
    ]
   },
   {
@@ -145,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,52 +171,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Publishing START_MIT_STAND\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# run simulation\n",
-    "sol = AtlasSim.run(final_time = 10.0);\n",
+    "controlΔt = 1 / 500\n",
+    "sol = AtlasSim.run(controlΔt = controlΔt, final_time = 10.0);\n",
     "flush(stdout)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[1m\u001b[32mTest Passed\u001b[39m\u001b[22m"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Simulated 10.0 s in 14.885309275 s (0.6718033072241961 x realtime).\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# checks\n",
     "finalstate = MechanismState(mechanism)\n",
     "copyto!(finalstate, sol.u[end])\n",
     "@test sol.retcode == :Success\n",
-    "@test center_of_mass(finalstate) ≈ comref atol=2e-2"
+    "@test center_of_mass(finalstate) ≈ comref atol=2e-2\n",
+    "@test norm(velocity(finalstate)) ≈ 0 atol=1e-5"
    ]
   },
   {

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -72,7 +72,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mLoading HttpServer methods...\n",
-      "\u001b[39m"
+      "\u001b[39mWARNING: using Juno.input in module InteractBase conflicts with an existing identifier.\n"
      ]
     }
    ],
@@ -83,33 +83,10 @@
     "using AtlasRobot\n",
     "using HumanoidLCMSim\n",
     "using HumanoidLCMSim.AtlasSim\n",
-    "using Compat.Test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: using Juno.input in module InteractBase conflicts with an existing identifier.\n"
-     ]
-    }
-   ],
-   "source": [
+    "\n",
     "# load URDF\n",
-    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism());"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "mechanism = AtlasSim.addflatground!(AtlasRobot.mechanism());\n",
+    "\n",
     "# create optimizer\n",
     "using MathOptInterface\n",
     "using OSQP.MathOptInterfaceOSQP\n",
@@ -119,15 +96,9 @@
     "MOI.set!(optimizer, OSQPSettings.EpsAbs(), 1e-5)\n",
     "MOI.set!(optimizer, OSQPSettings.EpsRel(), 1e-5)\n",
     "MOI.set!(optimizer, OSQPSettings.MaxIter(), 5000)\n",
-    "MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "MOI.set!(optimizer, OSQPSettings.AdaptiveRhoInterval(), 25) # required for deterministic behavior\n",
+    "sleep(0.5)\n",
+    "\n",
     "# create low level controller\n",
     "lowlevel = MomentumBasedController{4}(mechanism, optimizer);\n",
     "for body in bodies(mechanism)\n",
@@ -139,30 +110,16 @@
     "        contact.maxnormalforce[] = 1e6 # TODO\n",
     "        contact.weight[] = 1e-3\n",
     "    end\n",
-    "end"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "end\n",
+    "\n",
     "# create standing controller\n",
     "info = AtlasSim.atlasrobotinfo(mechanism)\n",
     "nominalstate = MechanismState(mechanism)\n",
     "AtlasSim.initialize!(nominalstate, info)\n",
     "pelvis = successor(info.floatingjoint, mechanism)\n",
     "comref = center_of_mass(nominalstate) - FreeVector3D(root_frame(mechanism), 0., 0., 0.05)\n",
-    "standingcontroller = StandingController(lowlevel, collect(values(info.feet)), pelvis, nominalstate, comref=comref);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "standingcontroller = StandingController(lowlevel, collect(values(info.feet)), pelvis, nominalstate, comref=comref);\n",
+    "\n",
     "# create LCM control publisher\n",
     "publisher = LCMControlPublisher(info, standingcontroller;\n",
     "    robot_state_channel=\"EST_ROBOT_STATE\",\n",
@@ -171,11 +128,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Task (queued) @0x00007f1222159270"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "handle(publisher, async=true)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Publishing START_MIT_STAND\n"
+     ]
+    }
+   ],
    "source": [
     "# run simulation\n",
+    "using HumanoidLCMSim\n",
     "controlΔt = 1 / 500\n",
     "sol = AtlasSim.run(controlΔt = controlΔt, final_time = 10.0);\n",
     "flush(stdout)"
@@ -183,11 +169,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1m\u001b[32mTest Passed\u001b[39m\u001b[22m"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Simulated 10.0 s in 16.178427033 s (0.6181070619289791 x realtime).\n"
+     ]
+    }
+   ],
    "source": [
     "# checks\n",
+    "using Compat.Test\n",
     "finalstate = MechanismState(mechanism)\n",
     "copyto!(finalstate, sol.u[end])\n",
     "@test sol.retcode == :Success\n",

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -134,7 +134,7 @@
     {
      "data": {
       "text/plain": [
-       "Task (queued) @0x00007f1222159270"
+       "Task (queued) @0x00007fe38d330fd0"
       ]
      },
      "execution_count": 2,
@@ -186,7 +186,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simulated 10.0 s in 16.178427033 s (0.6181070619289791 x realtime).\n"
+      "Simulated 10.0 s in 17.413842434 s (0.5742557989657299 x realtime).\n"
      ]
     }
    ],
@@ -197,7 +197,7 @@
     "copyto!(finalstate, sol.u[end])\n",
     "@test sol.retcode == :Success\n",
     "@test center_of_mass(finalstate) ≈ comref atol=2e-2\n",
-    "@test norm(velocity(finalstate)) ≈ 0 atol=1e-5"
+    "@test norm(velocity(finalstate)) ≈ 0 atol=1e-4"
    ]
   },
   {

--- a/notebooks/QPControl.ipynb
+++ b/notebooks/QPControl.ipynb
@@ -33,6 +33,7 @@
    "source": [
     "# create optimizer\n",
     "using MathOptInterface\n",
+    "using OSQP\n",
     "using OSQP.MathOptInterfaceOSQP\n",
     "const MOI = MathOptInterface\n",
     "const optimizer = OSQPOptimizer()\n",

--- a/src/HumanoidLCMSim.jl
+++ b/src/HumanoidLCMSim.jl
@@ -10,7 +10,8 @@ export # types
     Side
 
 export # functions
-    parse_actuators
+    parse_actuators,
+    handle
 
 export # submodules
     Sides,

--- a/src/HumanoidLCMSim.jl
+++ b/src/HumanoidLCMSim.jl
@@ -29,6 +29,9 @@ using BufferedStreams
 using LightXML
 using BotCoreLCMTypes
 import DataStructures: OrderedDict
+using Reexport
+
+@reexport using JSExpr # FIXME: needed because of https://github.com/JuliaGizmos/JSExpr.jl/issues/13
 
 include("gains.jl")
 include("sides.jl")

--- a/src/HumanoidLCMSim.jl
+++ b/src/HumanoidLCMSim.jl
@@ -4,7 +4,8 @@ module HumanoidLCMSim
 
 export # types
     HumanoidRobotInfo,
-    LCMController,
+    LCMControlReceiver,
+    LCMControlPublisher,
     Actuator,
     Side
 
@@ -33,8 +34,11 @@ include("sides.jl")
 
 using .Sides
 
+include("util.jl")
 include("humanoid_robot_info.jl")
-include("control.jl")
+include("lcm_interop.jl")
+include("controlreceiver.jl")
+include("controlpublisher.jl")
 
 include("atlas.jl")
 

--- a/src/atlas.jl
+++ b/src/atlas.jl
@@ -13,8 +13,7 @@ using DiffEqBase: CallbackSet, solve, init
 using OrdinaryDiffEq: Tsit5
 using DataStructures: OrderedDict
 using MechanismGeometries: URDFVisuals
-using JSExpr # FIXME: https://github.com/JunoLab/Blink.jl/issues/134
-using Blink: Window
+using JSExpr, Blink # FIXME: https://github.com/JunoLab/Blink.jl/issues/134
 
 function addflatground!(mechanism::Mechanism)
     frame = root_frame(mechanism)

--- a/src/atlas.jl
+++ b/src/atlas.jl
@@ -13,6 +13,7 @@ using DiffEqBase: CallbackSet, solve, init
 using OrdinaryDiffEq: Tsit5
 using DataStructures: OrderedDict
 using MechanismGeometries: URDFVisuals
+using JSExpr # FIXME: https://github.com/JunoLab/Blink.jl/issues/134
 using Blink: Window
 
 function addflatground!(mechanism::Mechanism)
@@ -103,7 +104,7 @@ using HumanoidLCMSim; AtlasSim.run()
 ```
 """
 function run(; final_time = Inf, controlΔt::Float64 = 1 / 300, headless = false, max_rate = Inf)
-    BLAS.set_num_threads(max(Sys.CPU_CORES - 3, 1)) # leave some cores for other processes
+    BLAS.set_num_threads(max(floor(Int, Sys.CPU_CORES / 2  - 1), 1)) # leave some cores for other processes
     mechanism = addflatground!(AtlasRobot.mechanism())
     info = atlasrobotinfo(mechanism)
     state0 = MechanismState(mechanism)
@@ -125,7 +126,7 @@ function run(; final_time = Inf, controlΔt::Float64 = 1 / 300, headless = false
     callback = CallbackSet(make_callback(state0, headless, max_rate), PeriodicCallback(pcontroller))
     sol, walltime = simulate(Dynamics(mechanism, control!), state0, final_time, callback)
     simtime = sol.t[end]
-    println("Simulated $simtime s in $walltime s ($(simtime / walltime) x realtime).")
+    println("Simulated $simtime s in $walltime s ($(simtime / walltime) × realtime).")
     sol
 end
 

--- a/src/controlpublisher.jl
+++ b/src/controlpublisher.jl
@@ -1,0 +1,55 @@
+struct LCMControlPublisher{M <:MechanismState, Tau, C}
+    state::M
+    controller::C
+    desired_controller_period_ms::Int
+    τ::Tau
+    robot_info::HumanoidRobotInfo{Float64}
+    lcm::LCM
+    robot_command_channel::String
+    atlas_command_msg::atlas_command_t
+    robot_state_msg::robot_state_t
+    encodebuffer::IOBuffer
+end
+
+function LCMControlPublisher(robot_info::HumanoidRobotInfo, controller::C;
+        robot_state_channel::String = "EST_ROBOT_STATE",
+        robot_command_channel::String = "ROBOT_COMMAND",
+        desired_controller_period_ms = 1) where {C}
+    mechanism = robot_info.mechanism
+    state = MechanismState(mechanism)
+    τ = similar(velocity(state))
+    lcm = LCM()
+    atlas_command_msg = atlas_command_t()
+    robot_state_msg = robot_state_t()
+    encodebuffer = IOBuffer(false, true)
+    publisher = LCMControlPublisher(state, controller, desired_controller_period_ms, τ, robot_info,
+        lcm, robot_command_channel, atlas_command_msg, robot_state_msg, encodebuffer)
+
+    atlas_command_msg.num_joints = num_actuators(robot_info)
+    resize!(atlas_command_msg)
+    for (i, actuator) in enumerate(actuators(robot_info))
+        atlas_command_msg.joint_names[i] = actuator.name
+    end
+
+    subscribe(lcm, robot_state_channel, (channel, data) -> handle_robot_state_msg(publisher, data))
+
+    @async while true
+        handle(lcm)
+    end
+
+    publisher
+end
+
+function handle_robot_state_msg(publisher::LCMControlPublisher, data::Vector{UInt8})
+    io = BufferedInputStream(data) # TODO: allocations
+    decode!(publisher.robot_state_msg, io)
+    set!(publisher.state, publisher.robot_state_msg, publisher.robot_info)
+    t = publisher.robot_state_msg.utime / 1e6
+    publisher.controller(publisher.τ, t, publisher.state)
+    state_des = publisher.state # TODO
+    set!(publisher.atlas_command_msg, publisher.τ, t, state_des, publisher.robot_info, publisher.desired_controller_period_ms)
+    encode(publisher.encodebuffer, publisher.atlas_command_msg)
+    bytes = take!(publisher.encodebuffer)
+    publish(publisher.lcm, publisher.robot_command_channel, bytes)
+    nothing
+end

--- a/src/controlpublisher.jl
+++ b/src/controlpublisher.jl
@@ -32,7 +32,8 @@ function LCMControlPublisher(robot_info::HumanoidRobotInfo, controller::C;
     end
 
     let publisher = publisher
-        subscribe(lcm, robot_state_channel, (channel, data) -> handle_robot_state_msg(publisher, data))
+        sub = subscribe(lcm, robot_state_channel, (channel, data) -> handle_robot_state_msg(publisher, data))
+        set_queue_capacity(sub, 1)
     end
 
     publisher

--- a/src/controlreceiver.jl
+++ b/src/controlreceiver.jl
@@ -70,7 +70,7 @@ function (receiver::LCMControlReceiver)(τ::AbstractVector, t::Number, state::Me
     end
 
     # process command
-    handle(receiver.lcm, Dates.Second(1))
+    LCMCore.handle(receiver.lcm, Dates.Second(1))
     receiver.new_command[] || throw(NoCommandError())
     set!(τ, receiver.tprev[] - t, state, receiver.τprev, receiver.atlas_command_msg, receiver.robot_info)
     receiver.new_command[] = false

--- a/src/controlreceiver.jl
+++ b/src/controlreceiver.jl
@@ -34,7 +34,10 @@ function LCMControlReceiver(robot_info::HumanoidRobotInfo;
     robot_state_msg.num_joints = length(robot_state_msg.joint_name)
     resize!(robot_state_msg)
 
-    subscribe(lcm, robot_command_channel, (channel, data) -> handle_robot_command_msg(receiver, data))
+    let receiver = receiver
+        sub = subscribe(lcm, robot_command_channel, (channel, data) -> handle_robot_command_msg(receiver, data))
+        set_queue_capacity(sub, 1)
+    end
 
     receiver
 end

--- a/src/controlreceiver.jl
+++ b/src/controlreceiver.jl
@@ -1,0 +1,90 @@
+struct LCMControlReceiver
+    result::DynamicsResult{Float64, Float64}
+    tprev::Base.RefValue{Float64}
+    τprev::Vector{Float64}
+    robot_info::HumanoidRobotInfo{Float64}
+    lcm::LCM
+    robot_state_channel::String
+    robot_state_msg::robot_state_t
+    atlas_command_msg::atlas_command_t
+    encodebuffer::IOBuffer
+    new_command::Base.RefValue{Bool}
+end
+
+# TODO: reduce cost of encoding
+
+function LCMControlReceiver(robot_info::HumanoidRobotInfo;
+        robot_state_channel::String = "EST_ROBOT_STATE",
+        robot_command_channel::String = "ROBOT_COMMAND")
+    mechanism = robot_info.mechanism
+    result = DynamicsResult(mechanism)
+    tprev = Ref(0.)
+    τprev = zeros(num_velocities(mechanism))
+    lcm = LCM()
+    robot_state_msg = robot_state_t()
+    atlas_command_msg = atlas_command_t()
+    encodebuffer = IOBuffer(false, true)
+    receiver = LCMControlReceiver(result, tprev, τprev, robot_info, lcm, robot_state_channel,
+        robot_state_msg, atlas_command_msg, encodebuffer, Ref(false))
+
+    for joint in tree_joints(mechanism)
+        num_velocities(joint) == 1 || continue
+        push!(robot_state_msg.joint_name, string(joint))
+    end
+    robot_state_msg.num_joints = length(robot_state_msg.joint_name)
+    resize!(robot_state_msg)
+
+    subscribe(lcm, robot_command_channel, (channel, data) -> handle_robot_command_msg(receiver, data))
+
+    receiver
+end
+
+function initialize!(receiver::LCMControlReceiver)
+    receiver.tprev[] = 0
+    receiver.τprev[:] = 0
+    nothing
+end
+
+function handle_robot_command_msg(receiver::LCMControlReceiver, data::Vector{UInt8})
+    io = BufferedInputStream(data)
+    msg = receiver.atlas_command_msg
+    decode!(msg, io)
+    receiver.new_command[] = true
+end
+
+function publish_robot_state(receiver::LCMControlReceiver, t::Number, state::MechanismState)
+    set!(receiver.robot_state_msg, receiver.result, receiver.robot_info, receiver.τprev, t, state)
+    encode(receiver.encodebuffer, receiver.robot_state_msg)
+    bytes = take!(receiver.encodebuffer)
+    publish(receiver.lcm, receiver.robot_state_channel, bytes)
+end
+
+struct NoCommandError <: Exception end
+Base.showerror(io::IO, e::NoCommandError) = print(io, "Didn't receive a command message.")
+
+function (receiver::LCMControlReceiver)(τ::AbstractVector, t::Number, state::MechanismState)
+    # send state info on first tick to get things started
+    if t == 0 # TODO: consider creating a separate flag in the controller for doing this
+        publish_robot_state(receiver, t, state)
+        sleep(0.5); publish_robot_state(receiver, t, state) # send a second time to work around a bug in the controller
+    end
+
+    # process command
+    handle(receiver.lcm, Dates.Second(1))
+    receiver.new_command[] || throw(NoCommandError())
+    set!(τ, receiver.tprev[] - t, state, receiver.τprev, receiver.atlas_command_msg, receiver.robot_info)
+    receiver.new_command[] = false
+    receiver.tprev[] = t
+    receiver.τprev[:] = τ
+
+    # send state info
+    publish_robot_state(receiver, t, state)
+    τ
+end
+
+function RigidBodySim.PeriodicController(Δt::Number, receiver::LCMControlReceiver) # TODO: switch order?
+    initialize = let receiver = receiver
+        (c, t, u, integrator) -> initialize!(receiver)
+    end
+    PeriodicController(zeros(receiver.τprev), Δt, receiver; initialize = initialize)
+end

--- a/src/humanoid_robot_info.jl
+++ b/src/humanoid_robot_info.jl
@@ -35,6 +35,7 @@ struct HumanoidRobotInfo{T}
     floatingbody::RigidBody{T}
     world_aligned_floating_body_frame::CartesianFrame3D
     actuatorconfig::OrderedDict{Actuator, JointID}
+    actuators::Vector{Actuator}
     revolutejoints::Vector{Joint{T, Revolute{T}}}
 
     function HumanoidRobotInfo(
@@ -51,18 +52,19 @@ struct HumanoidRobotInfo{T}
         floatingbody = successor(floatingjoint, mechanism)
         world_aligned_floating_body_frame = CartesianFrame3D("world_aligned_floating_body_frame")
         revolutejoints = Joint{T, Revolute{T}}[j for j in tree_joints(mechanism) if joint_type(j) isa Revolute{T}]
-        new{T}(mechanism, feet, hands, floatingjoint, floatingbody, world_aligned_floating_body_frame, actuatorconfig, revolutejoints)
+        actuators = collect(keys(actuatorconfig))
+        new{T}(mechanism, feet, hands, floatingjoint, floatingbody, world_aligned_floating_body_frame, actuatorconfig, actuators, revolutejoints)
     end
 end
 
-num_actuators(info::HumanoidRobotInfo) = length(info.actuatorconfig)
-actuators(info::HumanoidRobotInfo) = keys(info.actuatorconfig)
+num_actuators(info::HumanoidRobotInfo) = length(info.actuators)
+actuators(info::HumanoidRobotInfo) = info.actuators
 
 function findactuator(info::HumanoidRobotInfo, name::String)
     for actuator in actuators(info)
         actuator.name == name && return actuator
     end
-    throw(ArgumentError("Actuator with name \"$name\" not found"))
+    throw(KeyError(name))
 end
 
 findjointid(info::HumanoidRobotInfo, actuator::Actuator) = info.actuatorconfig[actuator]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,1 +1,4 @@
-range_to_ind(range) = (@assert length(range) == 1; first(range))
+function range_to_ind(range)
+    length(range) == 1 || throw(ArgumentError("length(range) != 1"))
+    first(range)
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,1 @@
+range_to_ind(range) = (@assert length(range) == 1; first(range))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 # TODO: QPControl
 NBInclude 2.0.0
+OSQP

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 # TODO: QPControl
 NBInclude 2.0.0
-OSQP
+OSQP 0.2.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+# TODO: QPControl
+NBInclude 2.0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ using RigidBodyDynamics
 using BotCoreLCMTypes
 import HumanoidLCMSim: set!
 
-@testset "robot_side_t -> MechanismState" begin
+@testset "robot_state_t -> MechanismState" begin
     mechanism = Valkyrie().mechanism
     remove_fixed_tree_joints!(mechanism)
     feet = Dict(Sides.left => findbody(mechanism, "leftFoot"), Sides.right => findbody(mechanism, "rightFoot"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,16 @@
 module HumanoidLCMSimTests
 
 module SideTest
-using Compat.Test
+using Compat.Test, Compat.Random
 using HumanoidLCMSim
+
+if isdefined(Random, :seed!)
+    using Random: seed!
+else
+    const seed! = srand
+end
+
+seed!(1)
 
 @testset "side" begin
     @test -Sides.left == Sides.right


### PR DESCRIPTION
* Rename `LCMController` -> `LCMControlReceiver`
* Add `LCMControlPublisher` (wrapper around a controller that listens for `robot_state_t` and publishes `atlas_command_t`)
* Use `LCMControlPublisher` to set up LCM communication for a `QPControl.StandingController`.
* Reorganize code a bit.

Looks like performance isn't as good as it should be (0.7 x realtime on my machine), but that can be addressed in a separate PR. The robot looks pretty shaky in the visualizer. I wonder if that's because of accuracy issues with encoding/decoding orientations. Also found https://github.com/JuliaRobotics/RigidBodySim.jl/issues/75 in the process of writing this. So not perfect, but a good start.

cc:@rdeits.